### PR TITLE
no tmp file; S3 response -> godotenv -> environment.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,8 +22,7 @@
 [[projects]]
   name = "github.com/joho/godotenv"
   packages = ["."]
-  revision = "726cc8b906e3d31c70a9671c90a13716a8d3f50d"
-  version = "v1.1"
+  revision = "9d9ddadf44b4c17c42bafdc530ddeee1927c067d"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -34,6 +33,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fab5ea323fd46edf462d477dc8fb35968ce7f17924e3a1283aa856f957532077"
+  inputs-digest = "56cf0e92a9cb3498f5c24d2a5bc33812e5db92472b9564eefc0070c115bc98f1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,8 @@
 
 [[constraint]]
   name = "github.com/joho/godotenv"
-  version = "1.1.0"
+  # https://github.com/joho/godotenv/pull/36
+  revision = "9d9ddadf44b4c17c42bafdc530ddeee1927c067d"
 
 [[constraint]]
   name = "github.com/pkg/errors"


### PR DESCRIPTION
As of https://github.com/joho/godotenv/pull/36 godotenv can parse an env file from a `io.Reader` instead of a file on disk. This removes some code, complexity and security concerns from s3dotenv.